### PR TITLE
Change: Move plugin/memolist.vim's settings and functions to autoload/memolist.vim for improve Vim startup performance

### DIFF
--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -1,6 +1,6 @@
 " autoload/memolist.vim
 " Author:  Akira Maeda <glidenote@gmail.com>
-"
+" Version: 0.0.2
 " Install this file as autoload/memolist.vim.  This file is sourced manually by
 " plugin/memolist.vim.  It is in autoload directory to allow for future usage of
 " Vim 7's autoload feature.
@@ -25,7 +25,125 @@ function! s:error(str)
   let v:errmsg = a:str
 endfunction
 " }}}1
-" Commands {{{1
+
+"------------------------
+" setting
+"------------------------
+if !exists('g:memolist_path')
+  let g:memolist_path = $HOME . "/memo"
+endif
+
+if !exists('g:memolist_memo_suffix')
+  let g:memolist_memo_suffix = "markdown"
+endif
+
+if !exists('g:memolist_memo_date')
+  let g:memolist_memo_date = "%Y-%m-%d %H:%M"
+endif
+
+if !exists('g:memolist_title_pattern')
+  let g:memolist_title_pattern = "[ '\"]"
+endif
+
+if !exists('g:memolist_prompt_tags')
+  let g:memolist_prompt_tags = ""
+endif
+
+if !exists('g:memolist_prompt_categories')
+  let g:memolist_prompt_categories = ""
+endif
+
+if !exists('g:memolist_qfixgrep')
+  let g:memolist_qfixgrep = ""
+endif
+
+function! s:esctitle(str)
+  let str = a:str
+  let str = tolower(str)
+  let str = substitute(str, g:memolist_title_pattern, '-', 'g')
+  let str = substitute(str, '\(--\)\+', '-', 'g')
+  let str = substitute(str, '\(^-\|-$\)', '', 'g')
+  return str
+endfunction
+
+if !isdirectory(g:memolist_path)
+  call mkdir(g:memolist_path, 'p')
+endif
+
+"------------------------
+" function
+"------------------------
+function! s:BufInit(path)
+  let b:memolist_root = a:path
+  echomsg b:memolist_root
+  if !exists("g:autoloaded_memolist") && v:version >= 700
+    runtime! autoload/memolist.vim
+  endif
+  " FIXME: This should be handled by the autocmd, but we don't set memolist_root
+  " until after that autocmd is run, so it won't match.
+  syn match Comment /\%^---\_.\{-}---$/ contains=@Spell
+endfunction
+
+function! memolist#list()
+  exe "e " . g:memolist_path
+endfunction
+
+function! memolist#grep(word)
+  let word = a:word
+  if word == ''
+    let word = input("MemoGrep word: ")
+  endif
+  let qfixgrep = g:memolist_qfixgrep
+  if qfixgrep == 'true'
+    exe "Vimgrep " word . " " . g:memolist_path . "/*"
+  else
+    exe "vimgrep " word . " " . g:memolist_path . "/*"
+  endif
+endfunction
+
+function! memolist#new(title)
+  let date = g:memolist_memo_date
+  let tags = g:memolist_prompt_tags
+  let categories = g:memolist_prompt_categories
+
+  if date == "epoch"
+    let date = localtime()
+  elseif date != ""
+    let date = strftime(date)
+  endif
+  let title = a:title
+  if title == ''
+    let title = input("Memo title: ")
+  endif
+  if tags != ""
+    let tags = input("Memo tags: ")
+  endif
+  if categories != ""
+    let categories = input("Memo categories: ")
+  endif
+  if title != ''
+    let file_name = strftime("%Y-%m-%d-") . s:esctitle(title) . "." . g:memolist_memo_suffix
+    echo "Making that memo " . file_name
+    exe "e " . g:memolist_path . "/" . file_name
+
+    " memo template
+    let template = ["title: " . title , "=========="]
+    if date != ""
+      call add(template, "date: "  . date)
+    endif
+    if tags != ""
+      call add(template, "tags: [" . tags . "]")
+    endif
+    if categories != ""
+      call add(template, "categories: [" . categories . "]")
+    endif
+    call extend(template,["- - -"])
+
+    let err = append(0, template)
+  else
+    call s:error("You must specify a title")
+  endif
+endfunction
 
 let &cpo = s:cpo_save
 

--- a/plugin/memolist.vim
+++ b/plugin/memolist.vim
@@ -1,6 +1,6 @@
-" memolist.vim  
+" memolist.vim
 " Maintainer:  Akira Maeda <glidenote@gmail.com>
-"
+" Version:  0.0.2
 " See doc/memolist.txt for instructions and usage.
 
 " Code {{{1
@@ -16,133 +16,9 @@ let g:loaded_memolist = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-"------------------------
-" setting
-"------------------------
-if !exists('g:memolist_path')
-  let g:memolist_path = $HOME . "/memo"
-endif
-
-if !exists('g:memolist_memo_suffix')
-  let g:memolist_memo_suffix = "markdown"
-endif
-
-if !exists('g:memolist_memo_date')
-  let g:memolist_memo_date = "%Y-%m-%d %H:%M"
-endif
-
-if !exists('g:memolist_title_pattern')
-  let g:memolist_title_pattern = "[ '\"]"
-endif
-
-if !exists('g:memolist_prompt_tags')
-  let g:memolist_prompt_tags = ""
-endif
-
-if !exists('g:memolist_prompt_categories')
-  let g:memolist_prompt_categories = ""
-endif
-
-if !exists('g:memolist_qfixgrep')
-  let g:memolist_qfixgrep = ""
-endif
-
-function s:esctitle(str)
-  let str = a:str
-  let str = tolower(str)
-  let str = substitute(str, g:memolist_title_pattern, '-', 'g')
-  let str = substitute(str, '\(--\)\+', '-', 'g')
-  let str = substitute(str, '\(^-\|-$\)', '', 'g')
-  return str
-endfunction
-
-function! s:error(str)
-  echohl ErrorMsg
-  echomsg a:str
-  echohl None
-  let v:errmsg = a:str
-endfunction
-
-if !isdirectory(g:memolist_path)                                                                                                                           
-  call mkdir(g:memolist_path, 'p')                                                                                                                         
-endif
-
-"------------------------
-" function
-"------------------------
-function! s:BufInit(path)
-  let b:memolist_root = a:path
-  if !exists("g:autoloaded_memolist") && v:version >= 700
-    runtime! autoload/memolist.vim
-  endif
-  " FIXME: This should be handled by the autocmd, but we don't set memolist_root
-  " until after that autocmd is run, so it won't match.
-  syn match Comment /\%^---\_.\{-}---$/ contains=@Spell
-endfunction
-
-function MemoList()
-  exe "e " . g:memolist_path 
-endfunction
-command! -nargs=0 MemoList :call MemoList()
-
-function MemoGrep(word)
-  let word = a:word
-  if word == ''
-    let word = input("MemoGrep word: ")
-  endif
-  let qfixgrep = g:memolist_qfixgrep
-  if qfixgrep == 'true'
-    exe "Vimgrep " word . " " . g:memolist_path . "/*"
-  else
-    exe "vimgrep " word . " " . g:memolist_path . "/*"
-  endif
-endfunction
-command! -nargs=? MemoGrep :call MemoGrep(<q-args>)
-
-function MemoNew(title)
-  let date = g:memolist_memo_date
-  let tags = g:memolist_prompt_tags
-  let categories = g:memolist_prompt_categories
-
-  if date == "epoch"
-    let date = localtime() 
-  elseif date != ""
-    let date = strftime(date)
-  endif
-  let title = a:title
-  if title == ''
-    let title = input("Memo title: ")
-  endif
-  if tags != ""
-    let tags = input("Memo tags: ")
-  endif
-  if categories != ""
-    let categories = input("Memo categories: ")
-  endif
-  if title != ''
-    let file_name = strftime("%Y-%m-%d-") . s:esctitle(title) . "." . g:memolist_memo_suffix
-    echo "Making that memo " . file_name
-    exe "e " . g:memolist_path . "/" . file_name
-    
-    " memo template
-    let template = ["title: " . title , "=========="]
-    if date != ""
-      call add(template, "date: "  . date)
-    endif
-    if tags != ""
-      call add(template, "tags: [" . tags . "]")
-    endif
-    if categories != ""
-      call add(template, "categories: [" . categories . "]")
-    endif
-    call extend(template,["- - -"])
-
-    let err = append(0, template)
-  else
-    call s:error("You must specify a title")
-  endif
-endfunction
-command! -nargs=? MemoNew :call MemoNew(<q-args>)
+command! -nargs=0 MemoList :call memolist#list()
+command! -nargs=? MemoGrep :call memolist#grep(<q-args>)
+command! -nargs=? MemoNew :call memolist#new(<q-args>)
 
 let &cpo = s:cpo_save
 


### PR DESCRIPTION
Vim は plugin 以下にあるものは起動時にメモリに読み込むため、実行されてしまいます。
(詳細は `h: write-plugin-quickload` を参照下さい)

plugin/memolist.vim はコマンドの定義をし、処理を autoload/memolist.vim へ移動しました。
またそれに伴いメソッド名をいくつか変更しました。

パッチ適応前

``` bash
$ vim --startuptime time.txt
197.220 000.439 000.439: sourcing /Users/heavenshell/.vim/bundle/memolist.vim/plugin/memolist.vim
```

パッチ適応後

``` bash
$ vim --startuptime time.txt
174.140 000.151 000.151: sourcing /Users/heavenshell/.vim/bundle/memolist.vim/plugin/memolist.vim
```

| パッチ適応前 | パッチ適応後 |
| --- | --- |
| 000.439 | 000.151 |
