### PR TITLE
Fix error when g:memolist_path set like ~/memo

### DIFF
--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -66,6 +66,7 @@ function! s:esctitle(str)
   return str
 endfunction
 
+let g:memolist_path = expand(g:memolist_path, 'p:')
 if !isdirectory(g:memolist_path)
   call mkdir(g:memolist_path, 'p')
 endif


### PR DESCRIPTION
let g:memolist_path = '~/memo' のように vimrc に設定すると以下のようなエラーになります。

```
"~/.vim-memolist/2012-03-29-sample.markdown" [新規ディレクトリ]
BufEnter Auto commands for "*" の処理中にエラーが検出されました:
E344: cdpathには "/Users/heavenshell/.vim-memolist" というファイルがありません
E472: コマンドが失敗しました
```

また自分のホームディレクトリに `~` というディレクトリが作成されます。
`expand(g:memolist_path, 'p:')`としパスを展開するように変更しました。
