### PR TITLE
Bits fix

### DIFF
--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -96,11 +96,15 @@ function! memolist#grep(word)
     return
   endif
   let qfixgrep = g:memolist_qfixgrep
-  if qfixgrep == 'true'
-    exe "Vimgrep" s:escarg(word) s:escarg(g:memolist_path . "/*")
-  else
-    exe "vimgrep" s:escarg(word) s:escarg(g:memolist_path . "/*")
-  endif
+  try
+    if qfixgrep == 'true'
+      exe "Vimgrep" s:escarg(word) s:escarg(g:memolist_path . "/*")
+    else
+      exe "vimgrep" s:escarg(word) s:escarg(g:memolist_path . "/*")
+    endif
+  catch
+    redraw | echohl ErrorMsg | echo v:exception | echohl None
+  endtry
 endfunction
 
 function! memolist#_complete_ymdhms(...)


### PR DESCRIPTION
2点細かい修正を行いました。

6213ba3f7172023e7db26c2a6c8fcaa5d8250476 カレントバッファが変更されている場合、`e`コマンドだとエラーを出すので`sp`にする修正

20a952e67487e2ecb2b2111c126121fc2c5f2426 vimgrepは見つからなかった場合に関数名を含むスタックトレースを出してしまうのでエラーのみ出力する様に修正
