### PR TITLE
Fix adding ^M to EOL when inserting templates

### DIFF
--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -135,7 +135,7 @@ function! memolist#new(title)
     let path = expand(g:memolist_template_dir_path, ":p")
     let path = path . "/" . g:memolist_memo_suffix . ".txt"
     if filereadable(path)
-      let template = readfile(path, 'b')
+      let template = readfile(path)
     endif
   endif
   " apply template


### PR DESCRIPTION
外部テンプレートファイルを利用する際に、set ff=dos の場合に、^Mが余分に行末に追加されてしまうのを修正しました。
