### PR TITLE
Add path separater characters to g:memolist_title_pattern

### DIFF
--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -38,7 +38,7 @@ if !exists('g:memolist_memo_date')
 endif
 
 if !exists('g:memolist_title_pattern')
-  let g:memolist_title_pattern = "[ '\"]"
+  let g:memolist_title_pattern = "[ /\\'\"]"
 endif
 
 if !exists('g:memolist_template_dir_path')


### PR DESCRIPTION
タイトルに `/` や `\` が入ると `:MemoNew` が失敗してしまうので、対策としてパス区切り文字列を`-`へ置換するように変更してみました。
