### PR TITLE
add memolist_filename_prefix_none. refs glidenote/memolist.vim#13

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,15 +31,29 @@ Grep Memo Directory:
 
 ## Options
 
+    " suffix type (default markdown)
     let g:memolist_memo_suffix = "markdown"
     let g:memolist_memo_suffix = "txt"
+
+    " date format (default %Y-%m-%d %H:%M)
     let g:memolist_memo_date = "%Y-%m-%d %H:%M"
     let g:memolist_memo_date = "epoch"
     let g:memolist_memo_date = "%D %T"
+
+    " tags prompt (default 0)
     let g:memolist_prompt_tags = 1
+
+    " categories prompt (default 0)
     let g:memolist_prompt_categories = 1
+
+    " use qfixgrep (default 0)
     let g:memolist_qfixgrep = 1
+
+    " use vimfler (default 0)
     let g:memolist_vimfiler = 1
+
+    " remove filename prefix (default 0)
+    let g:memolist_filename_prefix_none = 1
 
 you can use other format and custom template.
 (default memo format is `markdown`.)

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -124,7 +124,11 @@ function! memolist#new(title)
     let items['categories'] = join(split(input("Memo categories: "), '\s'), ' ')
   endif
 
-  let file_name = strftime("%Y-%m-%d-") . s:esctitle(items['title'])
+  if get(g:, 'memolist_filename_prefix_none', 0) != 0
+    let file_name = s:esctitle(items['title'])
+  else
+    let file_name = strftime("%Y-%m-%d-") . s:esctitle(items['title'])
+  endif
   if stridx(items['title'], '.') == -1
     let file_name = file_name . "." . g:memolist_memo_suffix
   endif

--- a/doc/memolist.txt
+++ b/doc/memolist.txt
@@ -21,15 +21,31 @@ The default memo suffix is "markdown". You can override these if you like.
 enable a prompt for memo tags and/or memo categories during create.
 
 Example: >
+    " suffix type (default markdown)
     let g:memolist_memo_suffix = "txt"
+
+    " date format (default %Y-%m-%d %H:%M)
     let g:memolist_memo_date = "%Y-%m-%d %H:%M"
     let g:memolist_memo_date = "epoch"
     let g:memolist_memo_date = "%D %T"
+
+    " tags prompt (default 0)
     let g:memolist_prompt_tags = 1
+
+    " categories prompt (default 0)
     let g:memolist_prompt_categories = 1
+
+    " use qfixgrep (default 0)
     let g:memolist_qfixgrep = 1
+
+    " use vimfler (default 0)
     let g:memolist_vimfiler = 1
+
+    " use template
     let g:memolist_template_dir_path = "path/to/dir"
+
+    " remove filename prefix (default 0)
+    let g:memolist_filename_prefix_none = 1
 <
 You may also want to add a few mappings to stream line the behavior: >
     map <Leader>mn  :MemoNew<CR>


### PR DESCRIPTION
add remove filename prefix option.

```
" remove filename prefix (default 0)
let g:memolist_filename_prefix_none = 1
```
