### PR TITLE
Added unite.vim support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,6 +31,7 @@ Grep Memo Directory:
 
 ## Options
 
+```vim
     " suffix type (default markdown)
     let g:memolist_memo_suffix = "markdown"
     let g:memolist_memo_suffix = "txt"
@@ -52,8 +53,12 @@ Grep Memo Directory:
     " use vimfler (default 0)
     let g:memolist_vimfiler = 1
 
+    " use unite (default 0)
+    let g:memolist_unite = 1
+
     " remove filename prefix (default 0)
     let g:memolist_filename_prefix_none = 1
+```
 
 you can use other format and custom template.
 (default memo format is `markdown`.)

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -49,6 +49,14 @@ if !exists('g:memolist_vimfiler_option')
   let g:memolist_vimfiler_option = "-split -winwidth=50"
 endif
 
+if !exists('g:memolist_unite_source')
+  let g:memolist_unite_source = "file"
+endif
+
+if !exists('g:memolist_unite_option')
+  let g:memolist_unite_option = ""
+endif
+
 function! s:esctitle(str)
   let str = a:str
   let str = tolower(str)
@@ -73,6 +81,8 @@ endif
 function! memolist#list()
   if get(g:, 'memolist_vimfiler', 0) != 0
     exe "VimFiler" g:memolist_vimfiler_option s:escarg(g:memolist_path)
+  elseif get(g:, 'memolist_unite', 0) != 0
+    exe "Unite" g:memolist_unite_source.':'.s:escarg(g:memolist_path) g:memolist_unite_option
   else
     exe "e" s:escarg(g:memolist_path)
   endif

--- a/doc/memolist.txt
+++ b/doc/memolist.txt
@@ -44,6 +44,15 @@ Example: >
     " use arbitrary vimfler option (default -split -winwidth=50)
     let g:memolist_vimfiler_option = "-split -winwidth=50 -simple"
 
+    " use unite (default 0)
+    let g:memolist_unite = 1
+
+    " use arbitrary unite option (default is empty)
+    let g:memolist_unite_option = "-auto-preview"
+
+    " use arbitrary unite source (default is 'file')
+    let g:memolist_unite_source = "file_rec"
+
     " use template
     let g:memolist_template_dir_path = "path/to/dir"
 


### PR DESCRIPTION
いつも便利に使わせてもらっています．ありがとうございます．

メモ一覧表示に unite.vim を使えるようにしました．現状では VimFiler のサポートが入っていますが，一覧から絞り込む処理をするなら unite.vim がより適任だと思ったからです．
- `g:memolist_unite`
  specify using unite.vim or not (defualt 0)
- `g:memolist_unite_source`
  specify a source of unite.vim (default 'file')
- `g:memolist_unite_option`
      specify options when a list of memo is opened with unite.vim
