### PR TITLE
Add Ex command support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -74,6 +74,10 @@ let g:memolist_unite_source = "file_rec"
 
 " use arbitrary unite option (default is empty)
 let g:memolist_unite_option = "-auto-preview -start-insert"
+
+" use various Ex commands (default '')
+let g:memolist_ex_cmd = 'CtrlP'
+let g:memolist_ex_cmd = 'NERDTree'
 ```
 
 ## memolist.vim with unite.vim
@@ -85,7 +89,7 @@ let g:memolist_unite_option = "-auto-preview -start-insert"
 you can use other format and custom template.
 (default memo format is `markdown`.)
 
-if you use custom template file(`~/memotemplates/rdoc.txt`).  
+if you use custom template file(`~/memotemplates/rdoc.txt`).
 add the following lines to your `.vimrc`
 
 ```

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -83,6 +83,8 @@ function! memolist#list()
     exe "VimFiler" g:memolist_vimfiler_option s:escarg(g:memolist_path)
   elseif get(g:, 'memolist_unite', 0) != 0
     exe "Unite" g:memolist_unite_source.':'.s:escarg(g:memolist_path) g:memolist_unite_option
+  elseif !empty(get(g:, 'memolist_ex_cmd', ''))
+    exe g:memolist_ex_cmd s:escarg(g:memolist_path)
   else
     exe "e" s:escarg(g:memolist_path)
   endif


### PR DESCRIPTION
`:MemoList` use the Ex command to open memolist forlder (if specified).

New variable:
- g:memolist_ex_cmd
  
  Specify Ex command to open the memolist folder
  ex: `let g:memolist_ex_cmd = "CtrlP"`
