### PR TITLE
modify memolist#new to wrapper for memolist#new_with_meta

### DIFF
--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -119,11 +119,15 @@ function! memolist#_complete_ymdhms(...)
 endfunction
 
 function! memolist#new(title)
+  call memolist#new_with_meta(a:title, [], [])
+endfunction
+
+function! memolist#new_with_meta(title, tags, categories)
   let items = {
   \ 'title': a:title,
   \ 'date':  localtime(),
-  \ 'tags':  [],
-  \ 'categories':  [],
+  \ 'tags':  a:tags,
+  \ 'categories': a:categories,
   \}
 
   if g:memolist_memo_date != 'epoch'

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -140,11 +140,11 @@ function! memolist#new_with_meta(title, tags, categories)
     return
   endif
 
-  if get(g:, 'memolist_prompt_tags', 0) != 0
+  if get(g:, 'memolist_prompt_tags', 0) != 0 && empty(items['tags'])
     let items['tags'] = join(split(input("Memo tags: "), '\s'), g:memolist_delimiter_yaml_array)
   endif
 
-  if get(g:, 'memolist_prompt_categories', 0) != 0
+  if get(g:, 'memolist_prompt_categories', 0) != 0 && empty(items['categories'])
     let items['categories'] = join(split(input("Memo categories: "), '\s'), g:memolist_delimiter_yaml_array)
   endif
 

--- a/doc/memolist.txt
+++ b/doc/memolist.txt
@@ -79,13 +79,27 @@ COMMANDS                                        *memolist-commands*
         let g:memolist_prompt_tags = 1
         let g:memolist_prompt_categories = 1
 <
+                                                *memolist-:MemoNewWithMeta*
+:MemoNewWithMeta        Create a new Memo passing tags and categories
+    Example: >
+        " ask you tags and categories if their prompt options are true.
+        :MemoNewWithMeta 'title', '', ''
+
+        " no ask you tags and categories always.
+        :MemoNewWithMeta 'title', 'tag1 tag2', 'category1 category2'
+
+        " ask you tags if g:memolist_prompt_tags is 1.
+        :MemoNewWithMeta 'title', '', 'category1 category2'
+
+        " ask you categories if g:memolist_prompt_categories is 1.
+        :MemoNewWithMeta 'title', 'tag1 tag2', ''
+<
                                                 *memolist-:MemoGrep*
 :MemoGrep               Grep Memo Directory
 
     You'll be asked to search the keyword like following: >
         MemoGrep word:
 <
-
 ==============================================================================
 TEMPLATE *memolist-template*
 

--- a/plugin/memolist.vim
+++ b/plugin/memolist.vim
@@ -23,6 +23,7 @@ endif
 command! -nargs=0 MemoList :call memolist#list()
 command! -nargs=? MemoGrep :call memolist#grep(<q-args>)
 command! -nargs=? MemoNew :call memolist#new(<q-args>)
+command! -nargs=* MemoNewWithMeta :call memolist#new_with_meta(<args>)
 
 let &cpo = s:cpo_save
 


### PR DESCRIPTION
新規メモを作成する際に、titleだけでなくtagsとcategoriesを引数で渡せるようにしました。

* 既存の`memolist#new`を`memolist#new_with_meta(title, tags, categories)`に変更。
* `memolist#new`は上記を呼び出すように変更。
* tags, categoriesのpromptオプションを有効になっている時に`new_with_meta()`を呼び出しても、空文字列が渡されていないものはpromptが表示されない。

初めての他人のリポジトリにプルリクエストを送るのはこれが初めてです。
不備がありましたら、ご指摘くださると助かります。