### PR TITLE
Add option g memolist delimiter of yaml flow style array

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,6 +78,9 @@ let g:memolist_unite_option = "-auto-preview -start-insert"
 " use various Ex commands (default '')
 let g:memolist_ex_cmd = 'CtrlP'
 let g:memolist_ex_cmd = 'NERDTree'
+
+" use delimiter of array in yaml front matter (default is ' ')
+let g:memolist_delimiter_yaml_array = ','
 ```
 
 ## memolist.vim with unite.vim

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -57,6 +57,10 @@ if !exists('g:memolist_unite_option')
   let g:memolist_unite_option = ""
 endif
 
+if !exists('g:memolist_delimiter_yaml_array')
+  let g:memolist_delimiter_yaml_array = " "
+endif
+
 function! s:esctitle(str)
   let str = a:str
   let str = tolower(str)
@@ -133,11 +137,11 @@ function! memolist#new(title)
   endif
 
   if get(g:, 'memolist_prompt_tags', 0) != 0
-    let items['tags'] = join(split(input("Memo tags: "), '\s'), ' ')
+    let items['tags'] = join(split(input("Memo tags: "), '\s'), g:memolist_delimiter_yaml_array)
   endif
 
   if get(g:, 'memolist_prompt_categories', 0) != 0
-    let items['categories'] = join(split(input("Memo categories: "), '\s'), ' ')
+    let items['categories'] = join(split(input("Memo categories: "), '\s'), g:memolist_delimiter_yaml_array)
   endif
 
   if get(g:, 'memolist_filename_prefix_none', 0) != 0


### PR DESCRIPTION
yaml front matterの配列のデリミタを、オプションで変更できるようにしました。
yamlのflow styleだと配列のデリミタはカンマだと思ったのですが、デフォルト値は以前と同じままにしております。

* オプション`g:memolist_delimiter_yaml_array`を追加。
* デフォルト値は、以前と同じで半角スペース1つ。

よろしくお願い致します。