### PR TITLE
Add memonew copying meta

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,6 +81,13 @@ let g:memolist_ex_cmd = 'NERDTree'
 
 " use delimiter of array in yaml front matter (default is ' ')
 let g:memolist_delimiter_yaml_array = ','
+
+" use when get items from yaml front matter
+  " first line string pattern of yaml front matter (default "==========")
+  let g:memolist_delimiter_yaml_array = "---"
+
+  " last line string pattern of yaml front matter (default "- - -")
+  let g:memolist_delimiter_yaml_array = "---"
 ```
 
 ## memolist.vim with unite.vim

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -25,6 +25,10 @@ function! s:error(str)
   let v:errmsg = a:str
 endfunction
 
+function! s:join_without_empty(string)
+  return join(split(a:string, '\v\s+'), g:memolist_delimiter_yaml_array)
+endfunction
+
 " retun lines contain beween start pattern and end pattern.
 " retun lines don't contain start pattern and end pattern.
 function! s:getline_regexp_range(start_pattern, end_pattern)
@@ -195,11 +199,11 @@ function! memolist#new_with_meta(title, tags, categories)
   endif
 
   if get(g:, 'memolist_prompt_tags', 0) != 0 && empty(items['tags'])
-    let items['tags'] = join(split(input("Memo tags: "), '\s'), g:memolist_delimiter_yaml_array)
+    let items['tags'] = s:join_without_empty(input("Memo tags: "))
   endif
 
   if get(g:, 'memolist_prompt_categories', 0) != 0 && empty(items['categories'])
-    let items['categories'] = join(split(input("Memo categories: "), '\s'), g:memolist_delimiter_yaml_array)
+    let items['categories'] = s:join_without_empty(input("Memo categories: "))
   endif
 
   if get(g:, 'memolist_filename_prefix_none', 0) != 0

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -184,8 +184,8 @@ function! memolist#new_with_meta(title, tags, categories)
   let items = {
   \ 'title': a:title,
   \ 'date':  localtime(),
-  \ 'tags':  a:tags,
-  \ 'categories': a:categories,
+  \ 'tags':  s:join_without_empty(a:tags),
+  \ 'categories': s:join_without_empty(a:categories),
   \}
 
   if g:memolist_memo_date != 'epoch'

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -25,10 +25,11 @@ function! s:error(str)
   let v:errmsg = a:str
 endfunction
 
-function! s:join_without_empty(string, ...)
-  if empty(a:string) | return '' | endif
+function! s:join_without_empty(list, ...)
+  if empty(a:list) | return '' | endif
   let pattern = a:0 > 0 ? a:1 : '\v\s+'
-  return join(split(a:string, pattern), g:memolist_delimiter_yaml_array)
+  return join(type(a:list) == type([]) ? a:list : split(a:list, pattern),
+        \ g:memolist_delimiter_yaml_array)
 endfunction
 
 " retun lines contain beween start pattern and end pattern.
@@ -177,9 +178,7 @@ function! memolist#new_copying_meta(title, exclude_item_names)
       end
     endfor
   endif
-  call memolist#new_with_meta(a:title, join(items['tags'],
-        \ g:memolist_delimiter_yaml_array), join(items['categories'],
-        \ g:memolist_delimiter_yaml_array))
+  call memolist#new_with_meta(a:title, items['tags'], items['categories'])
 endfunction
 
 function! memolist#new_with_meta(title, tags, categories)

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -169,16 +169,18 @@ function! memolist#new(title)
   call memolist#new_with_meta(a:title, [], [])
 endfunction
 
-function! memolist#new_copying_meta(title, exclude_item_names)
+function! memolist#new_copying_meta(...)
+  let title = a:0 > 0 ? a:1 : ''
+  let exclude_item_names = a:0 > 1 ? a:2 : ''
   let items =  s:get_items_from_yaml_front_matter()
-  if !empty(a:exclude_item_names)
-    for item_name in split(a:exclude_item_names, '\s')
+  if !empty(exclude_item_names)
+    for item_name in split(exclude_item_names, '\s')
       if has_key(items, item_name)
         let items[item_name] = type(items[item_name]) == type([]) ? [] : ''
       end
     endfor
   endif
-  call memolist#new_with_meta(a:title, items['tags'], items['categories'])
+  call memolist#new_with_meta(title, items['tags'], items['categories'])
 endfunction
 
 function! memolist#new_with_meta(title, tags, categories)

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -101,11 +101,11 @@ if !exists('g:memolist_delimiter_yaml_array')
 endif
 
 if !exists('g:memolist_delimiter_yaml_start')
-  let g:memolist_delimiter_yaml_array = "=========="
+  let g:memolist_delimiter_yaml_start = "=========="
 endif
 
 if !exists('g:memolist_delimiter_yaml_end')
-  let g:memolist_delimiter_yaml_array = "- - -"
+  let g:memolist_delimiter_yaml_end  = "- - -"
 endif
 
 function! s:esctitle(str)

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -25,8 +25,10 @@ function! s:error(str)
   let v:errmsg = a:str
 endfunction
 
-function! s:join_without_empty(string)
-  return join(split(a:string, '\v\s+'), g:memolist_delimiter_yaml_array)
+function! s:join_without_empty(string, ...)
+  if empty(a:string) | return '' | endif
+  let pattern = a:0 > 0 ? a:1 : '\v\s+'
+  return join(split(a:string, pattern), g:memolist_delimiter_yaml_array)
 endfunction
 
 " retun lines contain beween start pattern and end pattern.

--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -162,8 +162,15 @@ function! memolist#new(title)
   call memolist#new_with_meta(a:title, [], [])
 endfunction
 
-function! memolist#new_copying_meta(title)
+function! memolist#new_copying_meta(title, exclude_item_names)
   let items =  s:get_items_from_yaml_front_matter()
+  if !empty(a:exclude_item_names)
+    for item_name in split(a:exclude_item_names, '\s')
+      if has_key(items, item_name)
+        let items[item_name] = type(items[item_name]) == type([]) ? [] : ''
+      end
+    endfor
+  endif
   call memolist#new_with_meta(a:title, join(items['tags'],
         \ g:memolist_delimiter_yaml_array), join(items['categories'],
         \ g:memolist_delimiter_yaml_array))

--- a/doc/memolist.txt
+++ b/doc/memolist.txt
@@ -125,6 +125,11 @@ COMMANDS                                        *memolist-commands*
 
         " copy nothing
         :MemoNewCopyingMeta 'title', 'tags categories'
+
+        " You'll be asked title
+        :MemoNewCopyingMeta
+        :MemoNewCopyingMeta ''
+        :MemoNewCopyingMeta '', 'tags'
 <
                                                 *memolist-:MemoGrep*
 :MemoGrep               Grep Memo Directory

--- a/doc/memolist.txt
+++ b/doc/memolist.txt
@@ -101,8 +101,8 @@ COMMANDS                                        *memolist-commands*
 <
                                                 *memolist-:MemoNewCopyingMeta*
 :MemoNewCopyingMeta     Create a new Memo copying yaml front matter of you'are editting file
-    copy items: tags, categories
-    use current time as date and not copy the date of editting file
+    Copy items: tags, categories.
+    Use current time as date and not copy the date of editting file.
     Example: >
         " copy tags and categories
         :MemoNewCopyingMeta 'title'

--- a/doc/memolist.txt
+++ b/doc/memolist.txt
@@ -79,6 +79,11 @@ COMMANDS                                        *memolist-commands*
         let g:memolist_prompt_tags = 1
         let g:memolist_prompt_categories = 1
 <
+        Ignore first and last spaces and reguard consecutive spaces as one: >
+        " the following tags are [tag1, tag2]
+        tags:   tag1    tag2
+        tags: tag1 tag2
+<
                                                 *memolist-:MemoNewWithMeta*
 :MemoNewWithMeta        Create a new Memo passing tags and categories
     Example: >

--- a/doc/memolist.txt
+++ b/doc/memolist.txt
@@ -58,6 +58,16 @@ Example: >
 
     " remove filename prefix (default 0)
     let g:memolist_filename_prefix_none = 1
+
+    " use for tags and categories in yaml front matter (default " ")
+    let g:memolist_delimiter_yaml_array = ", "
+
+    " use when get items from yaml front matter
+      " first line string pattern of yaml front matter (default "==========")
+      let g:memolist_delimiter_yaml_array = "---"
+
+      " last line string pattern of yaml front matter (default "- - -")
+      let g:memolist_delimiter_yaml_array = "---"
 <
 You may also want to add a few mappings to stream line the behavior: >
     map <Leader>mn  :MemoNew<CR>

--- a/doc/memolist.txt
+++ b/doc/memolist.txt
@@ -94,6 +94,23 @@ COMMANDS                                        *memolist-commands*
         " ask you categories if g:memolist_prompt_categories is 1.
         :MemoNewWithMeta 'title', 'tag1 tag2', ''
 <
+                                                *memolist-:MemoNewCopyingMeta*
+:MemoNewCopyingMeta     Create a new Memo copying yaml front matter of you'are editting file
+    copy items: tags, categories
+    use current time as date and not copy the date of editting file
+    Example: >
+        " copy tags and categories
+        :MemoNewCopyingMeta 'title'
+
+        " copy categories
+        :MemoNewCopyingMeta 'title', 'tags'
+
+        " copy tags
+        :MemoNewCopyingMeta 'title', 'categories'
+
+        " copy nothing
+        :MemoNewCopyingMeta 'title', 'tags categories'
+<
                                                 *memolist-:MemoGrep*
 :MemoGrep               Grep Memo Directory
 

--- a/plugin/memolist.vim
+++ b/plugin/memolist.vim
@@ -24,6 +24,7 @@ command! -nargs=0 MemoList :call memolist#list()
 command! -nargs=? MemoGrep :call memolist#grep(<q-args>)
 command! -nargs=? MemoNew :call memolist#new(<q-args>)
 command! -nargs=* MemoNewWithMeta :call memolist#new_with_meta(<args>)
+command! -nargs=? MemoNewCopyingMeta :call memolist#new_copying_meta(<q-args>)
 
 let &cpo = s:cpo_save
 

--- a/plugin/memolist.vim
+++ b/plugin/memolist.vim
@@ -24,7 +24,7 @@ command! -nargs=0 MemoList :call memolist#list()
 command! -nargs=? MemoGrep :call memolist#grep(<q-args>)
 command! -nargs=? MemoNew :call memolist#new(<q-args>)
 command! -nargs=* MemoNewWithMeta :call memolist#new_with_meta(<args>)
-command! -nargs=? MemoNewCopyingMeta :call memolist#new_copying_meta(<q-args>)
+command! -nargs=* MemoNewCopyingMeta :call memolist#new_copying_meta(<args>)
 
 let &cpo = s:cpo_save
 


### PR DESCRIPTION
# summary
現在編集中のメモのタグとカテゴリをコピーして、新規メモを作成できるコマンドを追加しました。
同じテーマでメモを分けて書きたい時に、属性を記述する手間が省けます。
使い方はdocにサンプルを記述してあります。

ご検討、よろしくお願い致します。

# command
`:MemoNewCopyingMeta title(string), exclude_item_names(string)`を追加。

* dateとtitleは引き継がれません。
* デフォルトではcategoriesとtagsを引き継ぎます。オプションで除外するものを指定可能。
* `s:get_items_from_yaml_front_matter`では、yaml front matterに記述されている全ての属性を取得しています。dateとtitleも取ってきていますが、引き継ぎには使っていません。

# fix
* タグとカテゴリを尋ねるプロンプトで、連続した空白を入力しても1つ見なされるように修正。
* 以前は、連続した空白があると空の要素として記述されていた。