### PR TITLE
Implement get memolist files api

### DIFF
--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -162,6 +162,10 @@ function! memolist#list()
   endif
 endfunction
 
+function! memolist#files()
+  return systemlist('find ' . s:escarg(g:memolist_path) . ' -type f')
+endfunction
+
 function! memolist#grep(word)
   let word = a:word
   if word == ''


### PR DESCRIPTION
I would like to link [fzf-preview.vim](https://github.com/yuki-ycino/fzf-preview.vim) with memolist.vim.
I have read the code, but it seems that a function to get the list of files in memolist is needed for proper implementation.

If possible, I would like you to incorporate the function implemented in PR.