### PR TITLE
Fix to use glob instead of find command

### DIFF
--- a/autoload/memolist.vim
+++ b/autoload/memolist.vim
@@ -163,7 +163,7 @@ function! memolist#list()
 endfunction
 
 function! memolist#files()
-  return systemlist('find ' . s:escarg(g:memolist_path) . ' -type f')
+  return glob(printf('%s/**/*.*', s:escarg(g:memolist_path)), 1, 1)
 endfunction
 
 function! memolist#grep(word)


### PR DESCRIPTION
#44 implementation relied on the find command, which made it less portable.
Therefore, it has been modified to use globs in Vim script.